### PR TITLE
lmplement usage of secrets manager for database password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,11 @@ create-instance: ## Creates RDS Instance - mandatory: INSTANCE_NAME=[name];
 	-var 'instance_db_name=$(INSTANCE_NAME)'"
 	echo -e "\n\033[1mRDS Instance Details\033[00m"
 	echo -e "\nEndpoint:"
-	aws rds describe-db-instances --db-instance-identifier=test-rds-instance-nonprod | jq -r '.DBInstances[0].Endpoint.Address'
+	aws rds describe-db-instances --db-instance-identifier=$(INSTANCE_NAME)-nonprod | jq -r '.DBInstances[0].Endpoint.Address'
 	echo -e "\nUsername:"
-	aws rds describe-db-instances --db-instance-identifier=test-rds-instance-nonprod | jq -r '.DBInstances[0].MasterUsername'
+	aws rds describe-db-instances --db-instance-identifier=$(INSTANCE_NAME)-nonprod | jq -r '.DBInstances[0].MasterUsername'
 	echo -e "\nPassword Secret Endpoint:"
+	echo $(INSTANCE_NAME)-nonprod-dos_db_password
 
 download-sql-dump:
 	# TODO: Downlaod the latest DoS database SQL dump file

--- a/infrastructure/modules/rds/dos_db.tf
+++ b/infrastructure/modules/rds/dos_db.tf
@@ -11,7 +11,7 @@ module "db" {
 
     name     = var.db_name
     username = "postgres"
-    password = "YourPwdShouldBeLongAndSecure!"
+    password = aws_secretsmanager_secret_version.dos_test_db_password.secret_string
     port     = "5432"
 
     #iam_database_authentication_enabled = true

--- a/infrastructure/modules/rds/secrets.tf
+++ b/infrastructure/modules/rds/secrets.tf
@@ -1,0 +1,18 @@
+resource "aws_secretsmanager_secret" "dos_test_db_password" {
+    name                    = "${var.instance_db_name}-${var.cloud_env_type}-dos_db_password"
+    description             = "Password for the master Postgres DB user"
+    recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "dos_test_db_password" {
+    secret_id = aws_secretsmanager_secret.dos_test_db_password.id
+    secret_string = random_password.dos_test_db_password.result
+}
+
+resource "random_password" "dos_test_db_password" {
+    length      = 16
+    min_upper   = 2
+    min_lower   = 2
+    min_numeric = 2
+    special     = false
+}


### PR DESCRIPTION
Adds an implementation for generating a random password, and storings that in the AWS secrets manager, for the created RDS database instance.